### PR TITLE
Add AGENTS.md with development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Repository Overview
+
+This is a **data-only repository** containing a single Czech (Čeština) translation file (`cs.json`) for [Apache Guacamole Client](https://github.com/apache/guacamole-client). There is no application code, build system, package manager, or test framework.
+
+### Development Workflow
+
+- **Lint/Validate**: Use `python3 -c "import json; json.load(open('cs.json'))"` or `jq empty cs.json` to validate the JSON.
+- **Build**: N/A — no build step exists.
+- **Tests**: N/A — no automated test suite exists. Validation is JSON syntax checking.
+- **Run**: N/A — this is a static translation resource, not a runnable application.
+
+### Key Notes
+
+- The file `cs.json` must always be valid JSON (UTF-8 encoded).
+- Translation keys must match the structure of the upstream English source at `guacamole/src/main/frontend/src/translations/en.json` in the [apache/guacamole-client](https://github.com/apache/guacamole-client) repo.
+- Both `python3` and `jq` are available in the environment for JSON validation.
+- No dependencies need to be installed — the environment is ready to use out of the box.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 **Source file / Zdrojový soubor**
 
-* https://github.com/apache/guacamole-client/blob/master/guacamole/src/main/webapp/translations/en.json
+* https://github.com/apache/guacamole-client/blob/main/guacamole/src/main/frontend/src/translations/en.json
+* https://github.com/apache/guacamole-client/blob/patch/guacamole/src/main/frontend/src/translations/en.json
 
 **GUACAMOLE-781**
 
@@ -13,10 +14,6 @@
 * https://github.com/apache/guacamole-client/pull/397
 * https://github.com/apache/guacamole-client/pull/484
 * https://github.com/apache/guacamole-client/pull/610
-
-**Source file / Zdrojový soubor**
-
-* https://github.com/apache/guacamole-client/blob/master/guacamole/src/main/frontend/src/translations/en.json
 
 **GUACAMOLE-1644**
 
@@ -32,3 +29,8 @@
 
 * https://issues.apache.org/jira/browse/GUACAMOLE-1792
 * https://github.com/apache/guacamole-client/pull/876
+
+**GUACAMOLE-2125**
+
+* https://issues.apache.org/jira/browse/GUACAMOLE-2125
+* https://github.com/apache/guacamole-client/pull/1108

--- a/cs.json
+++ b/cs.json
@@ -43,6 +43,8 @@
         
         "FIELD_HEADER_PASSWORD"       : "Heslo:",
         "FIELD_HEADER_PASSWORD_AGAIN" : "Heslo znovu:",
+        "FIELD_HEADER_RECORDING_WRITE_EXISTING"  : "Povolit zápis do existujícího záznamového souboru:",
+        "FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING" : "Povolit zápis do existujícího souboru s textem:",
 
         "FIELD_PLACEHOLDER_FILTER" : "Filtr",
 
@@ -61,16 +63,18 @@
 
         "ACTION_ACKNOWLEDGE"               : "@:APP.ACTION_ACKNOWLEDGE",
         "ACTION_CANCEL"                    : "@:APP.ACTION_CANCEL",
-        "ACTION_CLEAR_CLIENT_MESSAGES"     : "Vyčistit",
-        "ACTION_CLEAR_COMPLETED_TRANSFERS" : "Vyčistit",
+        "ACTION_CLEAR_CLIENT_MESSAGES"     : "@:APP.ACTION_CLEAR",
+        "ACTION_CLEAR_COMPLETED_TRANSFERS" : "@:APP.ACTION_CLEAR",
         "ACTION_CONTINUE"                  : "@:APP.ACTION_CONTINUE",
         "ACTION_DISCONNECT"                : "Odpojit",
+        "ACTION_FULLSCREEN"                : "Celá obrazovka",
         "ACTION_LOGOUT"                    : "@:APP.ACTION_LOGOUT",
         "ACTION_NAVIGATE_BACK"             : "@:APP.ACTION_NAVIGATE_BACK",
         "ACTION_NAVIGATE_HOME"             : "@:APP.ACTION_NAVIGATE_HOME",
         "ACTION_RECONNECT"                 : "Znovu připojit",
         "ACTION_SAVE_FILE"                 : "@:APP.ACTION_SAVE",
         "ACTION_SHARE"                     : "@:APP.ACTION_SHARE",
+        "ACTION_SHOW_CLIPBOARD"            : "Kliknutím zobrazíte obsah schránky.",
         "ACTION_UPLOAD_FILES"              : "Nahrát soubory",
 
         "DIALOG_HEADER_CONNECTING"       : "Připojování",
@@ -163,7 +167,6 @@
         "TEXT_USER_LEFT"                  : "{USERNAME} opustil spojení.",
         "TEXT_RECONNECT_COUNTDOWN"        : "Znovu připojuji  {REMAINING} {REMAINING, plural, one{sekundu} other{sekund}}...",
         "TEXT_FILE_TRANSFER_PROGRESS"     : "{PROGRESS} {UNIT, select, b{B} kb{KB} mb{MB} gb{GB} other{}}",
-        "TEXT_CLIPBOARD_AWAITING_FOCUS"   : "Kliknutím zobrazíte obsah schránky...",
 
         "URL_OSK_LAYOUT" : "layouts/en-us-qwerty.json"
 
@@ -403,6 +406,7 @@
         "ERROR_PASSWORD_MISMATCH" : "@:APP.ERROR_PASSWORD_MISMATCH",
 
         "FIELD_HEADER_ADMINISTER_SYSTEM"             : "Spravovat systém:",
+        "FIELD_HEADER_AUDIT_SYSTEM"                  : "Zkontrolovat systém:",
         "FIELD_HEADER_CHANGE_OWN_PASSWORD"           : "Změnit vlastní heslo:",
         "FIELD_HEADER_CREATE_NEW_USERS"              : "Vytvořit nové uživatele:",
         "FIELD_HEADER_CREATE_NEW_USER_GROUPS"        : "Vytvořit novou uživatelskou skupinu:",
@@ -411,6 +415,7 @@
         "FIELD_HEADER_CREATE_NEW_SHARING_PROFILES"   : "Vytvořit nový sdílený profil:",
         "FIELD_HEADER_PASSWORD"                      : "@:APP.FIELD_HEADER_PASSWORD",
         "FIELD_HEADER_PASSWORD_AGAIN"                : "@:APP.FIELD_HEADER_PASSWORD_AGAIN",
+        "FIELD_HEADER_USER_DISABLED"                 : "Přihlášení zakázáno:",
         "FIELD_HEADER_USERNAME"                      : "Uživatelské jméno:",
 
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
@@ -443,12 +448,14 @@
         "DIALOG_HEADER_ERROR"          : "@:APP.DIALOG_HEADER_ERROR",
 
         "FIELD_HEADER_ADMINISTER_SYSTEM"             : "@:MANAGE_USER.FIELD_HEADER_ADMINISTER_SYSTEM",
+        "FIELD_HEADER_AUDIT_SYSTEM"                  : "@:MANAGE_USER.FIELD_HEADER_AUDIT_SYSTEM",
         "FIELD_HEADER_CHANGE_OWN_PASSWORD"           : "@:MANAGE_USER.FIELD_HEADER_CHANGE_OWN_PASSWORD",
         "FIELD_HEADER_CREATE_NEW_USERS"              : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_USERS",
         "FIELD_HEADER_CREATE_NEW_USER_GROUPS"        : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_USER_GROUPS",
         "FIELD_HEADER_CREATE_NEW_CONNECTIONS"        : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_CONNECTIONS",
         "FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS"  : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS",
         "FIELD_HEADER_CREATE_NEW_SHARING_PROFILES"   : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_SHARING_PROFILES",
+        "FIELD_HEADER_USER_GROUP_DISABLED"           : "Vypnuto:",
         "FIELD_HEADER_USER_GROUP_NAME"               : "Jméno skupiny:",
 
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
@@ -476,12 +483,19 @@
 
     "PLAYER" : {
 
-        "ACTION_CANCEL" : "@:APP.ACTION_CANCEL",
-        "ACTION_PAUSE"  : "@:APP.ACTION_PAUSE",
-        "ACTION_PLAY"   : "@:APP.ACTION_PLAY",
+        "ACTION_CANCEL"       : "@:APP.ACTION_CANCEL",
+        "ACTION_PAUSE"        : "@:APP.ACTION_PAUSE",
+        "ACTION_PLAY"         : "@:APP.ACTION_PLAY",
+        "ACTION_SHOW_KEY_LOG" : "Záznam stisků kláves",
 
-        "INFO_LOADING_RECORDING" : "Vaše nahrávka se nyní načítá. Čekejte prosím...",
-        "INFO_SEEK_IN_PROGRESS"  : "Hledání požadované pozice. Čekejte prosím..."
+        "INFO_FRAME_EVENTS_LEGEND" : "Aktivita na obrazovce",
+        "INFO_KEY_EVENTS_LEGEND"   : "Aktivita klávesnice",
+        "INFO_LOADING_RECORDING"   : "Vaše nahrávka se nyní načítá. Prosím, vyčkejte...",
+        "INFO_NO_KEY_LOG"          : "Záznam stisků kláves není k dispozici",
+        "INFO_NUMBER_OF_RESULTS"   : "{RESULTS} {RESULTS, plural, one{Match} other{Matches}}",
+        "INFO_SEEK_IN_PROGRESS"    : "Hledání požadované pozice. Čekejte prosím...",
+
+        "FIELD_PLACEHOLDER_TEXT_BATCH_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER"
 
     },
 
@@ -491,10 +505,13 @@
         "FIELD_HEADER_CA_CERT"         : "Certifikát certifikační autority:",
         "FIELD_HEADER_CLIENT_CERT"     : "Klientský certifikát:",
         "FIELD_HEADER_CLIENT_KEY"      : "Klientský klíč:",
+        "FIELD_HEADER_CLIPBOARD_BUFFER_SIZE" : "Limit velikosti dat ve schránce:",
         "FIELD_HEADER_COLOR_SCHEME"    : "Barevné schéma:",
         "FIELD_HEADER_CONTAINER"       : "Jméno kontejneru:",
         "FIELD_HEADER_CREATE_RECORDING_PATH"  : "Automaticky vytvořit cestu k záznamu:",
         "FIELD_HEADER_CREATE_TYPESCRIPT_PATH" : "Automaticky vytvořit cestu ke strojopisu:",
+        "FIELD_HEADER_DISABLE_COPY"    : "Zakázat kopírování ze vzdáleného terminálu:",
+        "FIELD_HEADER_DISABLE_PASTE"   : "Zakázat vkládání z klienta:",
         "FIELD_HEADER_EXEC_COMMAND"    : "Příkaz (exec):",
         "FIELD_HEADER_FONT_NAME"       : "Jméno fontu:",
         "FIELD_HEADER_FONT_SIZE"       : "Velikost fontu:",
@@ -504,6 +521,7 @@
         "FIELD_HEADER_POD"             : "Jméno podu:",
         "FIELD_HEADER_PORT"            : "Port:",
         "FIELD_HEADER_READ_ONLY"       : "Pouze ke čtení:",
+        "FIELD_HEADER_RECORDING_WRITE_EXISTING" : "@:APP.FIELD_HEADER_RECORDING_WRITE_EXISTING",
         "FIELD_HEADER_RECORDING_EXCLUDE_MOUSE"  : "Vyloučit myš:",
         "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT" : "Vyloučit grafiku/streamování:",
         "FIELD_HEADER_RECORDING_INCLUDE_KEYS"   : "Zahrnout události kláves:",
@@ -512,6 +530,7 @@
         "FIELD_HEADER_SCROLLBACK"      : "Maximální délka historie:",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Jméno strojopisu:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Cesta ke strojopisu:",
+        "FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING" : "@:APP.FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING",
         "FIELD_HEADER_USE_SSL"         : "Použít SSL/TLS",
 
         "FIELD_OPTION_BACKSPACE_EMPTY" : "",
@@ -544,6 +563,7 @@
 
         "SECTION_HEADER_AUTHENTICATION" : "Ověřování",
         "SECTION_HEADER_BEHAVIOR"       : "Chování terminálu",
+        "SECTION_HEADER_CLIPBOARD"      : "Schránka",
         "SECTION_HEADER_CONTAINER"      : "Kontejner",
         "SECTION_HEADER_DISPLAY"        : "Zobrazení",
         "SECTION_HEADER_RECORDING"      : "Záznam obrazovky",
@@ -554,20 +574,23 @@
 
     "PROTOCOL_RDP" : {
 
-        "FIELD_HEADER_CLIENT_NAME"     : "Jméno klienta:",
-        "FIELD_HEADER_COLOR_DEPTH"     : "Barevná hloubka:",
-        "FIELD_HEADER_CONSOLE"         : "Konzola pro správu:",
-        "FIELD_HEADER_CONSOLE_AUDIO"   : "Podpora zvuku v konzole:",
-        "FIELD_HEADER_CREATE_DRIVE_PATH" : "Automaticky vytvořit disk:",
+        "FIELD_HEADER_CERT_TOFU"             : "Důvěřovat certifikátu hostitele při prvním použití:",
+        "FIELD_HEADER_CERT_FINGERPRINTS"     : "Otisky důvěryhodných certifikátů hostitele:",
+        "FIELD_HEADER_CLIENT_NAME"           : "Jméno klienta:",
+        "FIELD_HEADER_CLIPBOARD_BUFFER_SIZE" : "Limit velikosti dat ve schránce:",
+        "FIELD_HEADER_COLOR_DEPTH"           : "Barevná hloubka:",
+        "FIELD_HEADER_CONSOLE"               : "Konzola pro správu:",
+        "FIELD_HEADER_CONSOLE_AUDIO"         : "Podpora zvuku v konzole:",
+        "FIELD_HEADER_CREATE_DRIVE_PATH"     : "Automaticky vytvořit disk:",
         "FIELD_HEADER_CREATE_RECORDING_PATH" : "Automaticky vytvořit cestu k záznamu:",
-        "FIELD_HEADER_DISABLE_AUDIO"   : "Zakázat zvuk:",
-        "FIELD_HEADER_DISABLE_AUTH"    : "Zakázat ověřování:",
-        "FIELD_HEADER_DISABLE_COPY"    : "Zakázat kopírování ze vzdálené plochy:",
+        "FIELD_HEADER_DISABLE_AUDIO"    : "Zakázat zvuk:",
+        "FIELD_HEADER_DISABLE_AUTH"     : "Zakázat ověřování:",
+        "FIELD_HEADER_DISABLE_COPY"     : "Zakázat kopírování ze vzdálené plochy:",
         "FIELD_HEADER_DISABLE_DOWNLOAD" : "Zakázat stahování souborů:",
-        "FIELD_HEADER_DISABLE_PASTE"   : "Zakázat vkládání z klienta:",
+        "FIELD_HEADER_DISABLE_PASTE"    : "Zakázat vkládání z klienta:",
         "FIELD_HEADER_DISABLE_UPLOAD"   : "Zakázat nahrávání souborů:",
-        "FIELD_HEADER_DOMAIN"          : "Doména:",
-        "FIELD_HEADER_DPI"             : "Rozlišení (DPI):",
+        "FIELD_HEADER_DOMAIN"           : "Doména:",
+        "FIELD_HEADER_DPI"              : "Rozlišení (DPI):",
         "FIELD_HEADER_DRIVE_NAME"       : "Název jednotky:",
         "FIELD_HEADER_DRIVE_PATH"       : "Cesta na disku:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Povolit zvukový vstup (mikrofon):",
@@ -600,9 +623,10 @@
         "FIELD_HEADER_PASSWORD"        : "Heslo:",
         "FIELD_HEADER_PORT"            : "Port:",
         "FIELD_HEADER_PRINTER_NAME"    : "Název přesměrované tiskárny:",
-        "FIELD_HEADER_PRECONNECTION_BLOB" : "Preconnection BLOB (VM ID):",
+        "FIELD_HEADER_PRECONNECTION_BLOB" : "Předběžné připojení BLOB (VM ID):",
         "FIELD_HEADER_PRECONNECTION_ID"   : "Zdrojové ID RDP:",
         "FIELD_HEADER_READ_ONLY"      : "Pouze ke čtení:",
+        "FIELD_HEADER_RECORDING_WRITE_EXISTING" : "@:APP.FIELD_HEADER_RECORDING_WRITE_EXISTING",
         "FIELD_HEADER_RECORDING_EXCLUDE_MOUSE"  : "Vyloučit myš:",
         "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT" : "Vyloučit grafiku/strímování:",
         "FIELD_HEADER_RECORDING_EXCLUDE_TOUCH"  : "Vyloučit dotykové události:",
@@ -617,6 +641,7 @@
         "FIELD_HEADER_SERVER_LAYOUT"   : "Rozložení klávesnice:",
         "FIELD_HEADER_SFTP_DIRECTORY"             : "Výchozí složka pro uložení záznamu:",
         "FIELD_HEADER_SFTP_DISABLE_DOWNLOAD"      : "Zakázat stahování souborů:",
+        "FIELD_HEADER_SFTP_DISABLE_UPLOAD"        : "Zakázat nahrávání souborů:",
         "FIELD_HEADER_SFTP_HOST_KEY"              : "Veřejný klíč hosta (Base64):",
         "FIELD_HEADER_SFTP_HOSTNAME"              : "Jméno hostitele:",
         "FIELD_HEADER_SFTP_SERVER_ALIVE_INTERVAL" : "Interval udržování SFTP:",
@@ -624,10 +649,12 @@
         "FIELD_HEADER_SFTP_PASSWORD"              : "Heslo:",
         "FIELD_HEADER_SFTP_PORT"                  : "Port:",
         "FIELD_HEADER_SFTP_PRIVATE_KEY"           : "Privátní klíč:",
+        "FIELD_HEADER_SFTP_PUBLIC_KEY"            : "Veřejný klíč:",
         "FIELD_HEADER_SFTP_ROOT_DIRECTORY"        : "Souborový prohlížeč kořenové složky:",
-        "FIELD_HEADER_SFTP_DISABLE_UPLOAD"        : "Zakázat nahrávání souborů:",
+        "FIELD_HEADER_SFTP_TIMEOUT"               : "Časový limit připojení SFTP:",
         "FIELD_HEADER_SFTP_USERNAME"              : "Uživatelské jméno:",
         "FIELD_HEADER_STATIC_CHANNELS" : "Názvy statických kanálů:",
+        "FIELD_HEADER_TIMEOUT"         : "Časový limit připojení",
         "FIELD_HEADER_TIMEZONE"        : "Časová zóna:",
         "FIELD_HEADER_USERNAME"        : "Uživatelské jméno:",
         "FIELD_HEADER_WIDTH"           : "Šířka:",
@@ -659,6 +686,8 @@
         "FIELD_OPTION_SECURITY_TLS"       : "Šifrování TLS",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Čeština (Qwertz)",
+        "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Dánština (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Švícarská Němčina (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "Němčina (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_EMPTY"        : "",
@@ -680,7 +709,6 @@
         "FIELD_OPTION_SERVER_LAYOUT_PT_PT_QWERTY" : "Portugalština (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_RO_RO_QWERTY" : "Rumunština (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY" : "Švédština (Qwerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Dánština (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_TR_TR_QWERTY" : "Turečtina (Qwerty)",
 
         "NAME" : "RDP",
@@ -705,6 +733,7 @@
     "PROTOCOL_SSH" : {
 
         "FIELD_HEADER_BACKSPACE"    : "Klávesa Zpět odešle:",
+        "FIELD_HEADER_CLIPBOARD_BUFFER_SIZE" : "Limit velikosti dat ve schránce:",
         "FIELD_HEADER_COLOR_SCHEME" : "Barva:",
         "FIELD_HEADER_COMMAND"      : "Provést příkaz:",
         "FIELD_HEADER_CREATE_RECORDING_PATH" : "Automaticky vytvořit cestu pro uložení záznamu:",
@@ -722,8 +751,10 @@
         "FIELD_HEADER_PASSPHRASE"    : "Přístupová fráze:",
         "FIELD_HEADER_PORT"          : "Port:",
         "FIELD_HEADER_PRIVATE_KEY"   : "Privátní klíč:",
+        "FIELD_HEADER_PUBLIC_KEY"    : "Veřejný klíč:",
         "FIELD_HEADER_SCROLLBACK"    : "Maximální délka historie:",
         "FIELD_HEADER_READ_ONLY"     : "Pouze ke čtení:",
+        "FIELD_HEADER_RECORDING_WRITE_EXISTING" : "@:APP.FIELD_HEADER_RECORDING_WRITE_EXISTING",
         "FIELD_HEADER_RECORDING_EXCLUDE_MOUSE"  : "Vynechat myš:",
         "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT" : "Vynechat grafiku/streamování:",
         "FIELD_HEADER_RECORDING_INCLUDE_KEYS"   : "Zahrnout události kláves:",
@@ -734,9 +765,11 @@
         "FIELD_HEADER_SFTP_ROOT_DIRECTORY"   : "Souborový prohlížeč kořenové složky:",
         "FIELD_HEADER_SFTP_DISABLE_UPLOAD"   : "Zakázat nahrávání souborů:",
         "FIELD_HEADER_TERMINAL_TYPE"   : "Typ terminálu:",
+        "FIELD_HEADER_TIMEOUT"         : "Časový limit připojení:",
         "FIELD_HEADER_TIMEZONE"        : "Časová zóna ($TZ):",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Jméno strojopisu:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Cesta ke strojopisu:",
+        "FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING" : "@:APP.FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING",
         "FIELD_HEADER_WOL_BROADCAST_ADDR" : "Vysílací adresa pro paket WoL:",
         "FIELD_HEADER_WOL_MAC_ADDR"       : "MAC adresa vzdáleného hosta:",
         "FIELD_HEADER_WOL_SEND_PACKET"    : "Odeslat paket WoL:",
@@ -795,6 +828,7 @@
     "PROTOCOL_TELNET" : {
 
         "FIELD_HEADER_BACKSPACE"      : "Klávesa Zpět odešle:",
+        "FIELD_HEADER_CLIPBOARD_BUFFER_SIZE" : "Limit velikosti dat ve schránce:",
         "FIELD_HEADER_COLOR_SCHEME"   : "Barevné schéma:",
         "FIELD_HEADER_CREATE_RECORDING_PATH" : "Automaticky vytvořit cestu pro uložení záznamu:",
         "FIELD_HEADER_CREATE_TYPESCRIPT_PATH" : "Automaticky vytvořit cestu ke strojopisu:",
@@ -811,6 +845,7 @@
         "FIELD_HEADER_PASSWORD_REGEX" : "Heslo regulární výraz:",
         "FIELD_HEADER_PORT"           : "Port:",
         "FIELD_HEADER_READ_ONLY"      : "Pouze ke čtení:",
+        "FIELD_HEADER_RECORDING_WRITE_EXISTING" : "@:APP.FIELD_HEADER_RECORDING_WRITE_EXISTING",
         "FIELD_HEADER_RECORDING_EXCLUDE_MOUSE"  : "Vyloučit myš:",
         "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT" : "Vyloučit grafiku/streamování:",
         "FIELD_HEADER_RECORDING_INCLUDE_KEYS"   : "Zahrnout klíčové události:",
@@ -818,8 +853,10 @@
         "FIELD_HEADER_RECORDING_PATH" : "Cesta pro záznam:",
         "FIELD_HEADER_SCROLLBACK"     : "Maximální délka historie:",
         "FIELD_HEADER_TERMINAL_TYPE"   : "Typ terminálu:",
+        "FIELD_HEADER_TIMEOUT"         : "Časový limit připojení:",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Jméno strojopisu:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Cesta ke strojopisu:",
+        "FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING" : "@:APP.FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING",
         "FIELD_HEADER_WOL_BROADCAST_ADDR" : "Vysílací adresa pro paket WoL:",
         "FIELD_HEADER_WOL_MAC_ADDR"       : "MAC adresa vzdáleného hosta:",
         "FIELD_HEADER_WOL_SEND_PACKET"    : "Odeslat paket WoL:",
@@ -876,22 +913,29 @@
     "PROTOCOL_VNC" : {
 
         "FIELD_HEADER_AUDIO_SERVERNAME" : "Název zvukového serveru:",
+        "FIELD_HEADER_CLIPBOARD_BUFFER_SIZE"  : "Limit velikosti dat ve schránce:",
         "FIELD_HEADER_CLIPBOARD_ENCODING" : "Kódovávání:",
         "FIELD_HEADER_COLOR_DEPTH"      : "Hloubka barev:",
+        "FIELD_HEADER_COMPRESS_LEVEL"   : "Úroveň komprese:",
         "FIELD_HEADER_CREATE_RECORDING_PATH" : "Automaticky vytvořit cestu pro uložení záznamu:",
         "FIELD_HEADER_CURSOR"           : "Kurzor:",
         "FIELD_HEADER_DEST_HOST"        : "Cílový host:",
         "FIELD_HEADER_DEST_PORT"        : "Vzdálený port:",
-        "FIELD_HEADER_DISABLE_COPY"     : "Zakázat kopírování ze vzdálené plochy:",
-        "FIELD_HEADER_DISABLE_PASTE"    : "Zakázat vkládání z klienta:",
+        "FIELD_HEADER_DISABLE_COPY"           : "Zakázat kopírování ze vzdálené plochy:",
+        "FIELD_HEADER_DISABLE_DISPLAY_RESIZE" : "Zakázat změnu velikosti vzdáleného displeje:",
+        "FIELD_HEADER_DISABLE_PASTE"          : "Zakázat vkládání z klienta:",
+        "FIELD_HEADER_DISABLE_SERVER_INPUT"   : "Zakázat vstup serveru, když je připojen klient:",
         "FIELD_HEADER_ENABLE_AUDIO"     : "Zapnout audio:",
         "FIELD_HEADER_ENABLE_SFTP"      : "Povolit SFTP:",
+        "FIELD_HEADER_ENCODINGS"        : "Zobrazit kódování:",
         "FIELD_HEADER_FORCE_LOSSLESS"   : "Vynutit bezeztrátovou kompresi:",
         "FIELD_HEADER_HOSTNAME"         : "Jméno hostitele:",
         "FIELD_HEADER_USERNAME"         : "Uživatelské jméno:",
         "FIELD_HEADER_PASSWORD"         : "Heslo:",
         "FIELD_HEADER_PORT"             : "Port:",
+        "FIELD_HEADER_QUALITY_LEVEL"    : "Kvalita zobrazení:",
         "FIELD_HEADER_READ_ONLY"        : "Pouze čtení:",
+        "FIELD_HEADER_RECORDING_WRITE_EXISTING" : "@:APP.FIELD_HEADER_RECORDING_WRITE_EXISTING",
         "FIELD_HEADER_RECORDING_EXCLUDE_MOUSE"  : "Vynechat myš:",
         "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT" : "Vynechat grafiku/stremování:",
         "FIELD_HEADER_RECORDING_INCLUDE_KEYS"   : "Zahrnout události kláves:",
@@ -899,6 +943,7 @@
         "FIELD_HEADER_RECORDING_PATH" : "Cesta pro záznam:",
         "FIELD_HEADER_SFTP_DIRECTORY"             : "Výchozí složka pro uložení záznamu:",
         "FIELD_HEADER_SFTP_DISABLE_DOWNLOAD"      : "Zakázat stahování souborů:",
+        "FIELD_HEADER_SFTP_DISABLE_UPLOAD"        : "Zakázat nahrávání souborů:",
         "FIELD_HEADER_SFTP_HOST_KEY"              : "Veřejný klíč hosta (Base64):",
         "FIELD_HEADER_SFTP_HOSTNAME"              : "Jméno hostitele:",
         "FIELD_HEADER_SFTP_SERVER_ALIVE_INTERVAL" : "Interval udržování SFTP:",
@@ -906,8 +951,9 @@
         "FIELD_HEADER_SFTP_PASSWORD"              : "Heslo:",
         "FIELD_HEADER_SFTP_PORT"                  : "Port:",
         "FIELD_HEADER_SFTP_PRIVATE_KEY"           : "Privátní klíč:",
+        "FIELD_HEADER_SFTP_PUBLIC_KEY"            : "Veřejný klíč:",
         "FIELD_HEADER_SFTP_ROOT_DIRECTORY"        : "Souborový prohlížeč kořenové složky:",
-        "FIELD_HEADER_SFTP_DISABLE_UPLOAD"        : "Zakázat nahrávání souborů:",
+        "FIELD_HEADER_SFTP_TIMEOUT"               : "Časový limit připojení SFTP:",
         "FIELD_HEADER_SFTP_USERNAME"              : "Uživatelské jméno:",
         "FIELD_HEADER_SWAP_RED_BLUE"    : "Přehodit červené/modré komponenty:",
         "FIELD_HEADER_WOL_BROADCAST_ADDR" : "Vysílací adresa pro paket WoL:",
@@ -916,11 +962,13 @@
         "FIELD_HEADER_WOL_UDP_PORT"       : "UDP port pro paket WoL:",
         "FIELD_HEADER_WOL_WAIT_TIME"      : "Doba čekání na spuštění hostitele:",
 
+
         "FIELD_OPTION_COLOR_DEPTH_8"     : "256 barev",
         "FIELD_OPTION_COLOR_DEPTH_16"    : "Nízké barvy (16-bitů)",
         "FIELD_OPTION_COLOR_DEPTH_24"    : "Opravdové barvy (24-bitů)",
         "FIELD_OPTION_COLOR_DEPTH_32"    : "Opravdové barvy (32-bitů)",
         "FIELD_OPTION_COLOR_DEPTH_EMPTY" : "",
+
 
         "FIELD_OPTION_CURSOR_EMPTY"  : "",
         "FIELD_OPTION_CURSOR_LOCAL"  : "Místní",
@@ -1012,14 +1060,17 @@
         "ERROR_PASSWORD_BLANK"    : "@:APP.ERROR_PASSWORD_BLANK",
         "ERROR_PASSWORD_MISMATCH" : "@:APP.ERROR_PASSWORD_MISMATCH",
 
-        "FIELD_HEADER_LANGUAGE"           : "Jazyk zobrazení:",
-        "FIELD_HEADER_PASSWORD"           : "Heslo:",
-        "FIELD_HEADER_PASSWORD_OLD"       : "Aktuální heslo:",
-        "FIELD_HEADER_PASSWORD_NEW"       : "Nové heslo:",
-        "FIELD_HEADER_PASSWORD_NEW_AGAIN" : "Potvrďte nové heslo:",
-        "FIELD_HEADER_TIMEZONE"           : "Časové pásmo:",
-        "FIELD_HEADER_USERNAME"           : "Uživatelské jméno:",
+        "FIELD_HEADER_LANGUAGE"                  : "Jazyk zobrazení:",
+        "FIELD_HEADER_NUMBER_RECENT_CONNECTIONS" : "Počet posledních připojení k zobrazení:",
+        "FIELD_HEADER_PASSWORD"                  : "Heslo:",
+        "FIELD_HEADER_PASSWORD_OLD"              : "Aktuální heslo:",
+        "FIELD_HEADER_PASSWORD_NEW"              : "Nové heslo:",
+        "FIELD_HEADER_PASSWORD_NEW_AGAIN"        : "Potvrďte nové heslo:",
+        "FIELD_HEADER_SHOW_RECENT_CONNECTIONS"   : "Zobrazit poslední připojení:",
+        "FIELD_HEADER_TIMEZONE"                  : "Časové pásmo:",
+        "FIELD_HEADER_USERNAME"                  : "Uživatelské jméno:",
         
+        "HELP_APPEARANCE"           : "Zde můžete povolit nebo zakázat zobrazení sekce \"Poslední připojení\" na domovské obrazovce a upravit počet zobrazených posledních připojení.",
         "HELP_DEFAULT_INPUT_METHOD" : "Výchozí metoda vstupu určuje, jak Guacamole přijímá události klávesnice. Změna tohoto nastavení může být nezbytná při používání mobilního zařízení nebo při psaní přes IME. Toto nastavení může být přepsáno na základě připojení v rámci nabídky Guacamole.",
         "HELP_DEFAULT_MOUSE_MODE"   : "Výchozí režim emulace myši určuje, jak se bude vzdálená myš chovat v nových spojeních s ohledem na dotyky. Toto nastavení může být přepsáno na základě připojení v rámci nabídky Guacamole.",
         "HELP_INPUT_METHOD_NONE"    : "@:CLIENT.HELP_INPUT_METHOD_NONE",
@@ -1037,6 +1088,7 @@
         "NAME_INPUT_METHOD_OSK"  : "@:CLIENT.NAME_INPUT_METHOD_OSK",
         "NAME_INPUT_METHOD_TEXT" : "@:CLIENT.NAME_INPUT_METHOD_TEXT",
 
+        "SECTION_HEADER_APPEARANCE"           : "Vzhled",
         "SECTION_HEADER_DEFAULT_INPUT_METHOD" : "Výchozí metoda vstupu",
         "SECTION_HEADER_DEFAULT_MOUSE_MODE"   : "Výchozí mód emulace myši",
         "SECTION_HEADER_UPDATE_PASSWORD"      : "Změnit heslo"
@@ -1046,7 +1098,7 @@
     "SETTINGS_USERS" : {
 
         "ACTION_ACKNOWLEDGE"   : "@:APP.ACTION_ACKNOWLEDGE",
-        "ACTION_NEW_USER"    : "Nový uživatel",
+        "ACTION_NEW_USER"      : "Nový uživatel",
 
         "DIALOG_HEADER_ERROR" : "@:APP.DIALOG_HEADER_ERROR",
 
@@ -1058,10 +1110,10 @@
 
         "SECTION_HEADER_USERS" : "Uživatel",
 
-        "TABLE_HEADER_FULL_NAME"    : "Celé jméno",
-        "TABLE_HEADER_LAST_ACTIVE"  : "Naposledy aktivní",
+        "TABLE_HEADER_FULL_NAME"   : "Celé jméno",
+        "TABLE_HEADER_LAST_ACTIVE" : "Naposledy aktivní",
         "TABLE_HEADER_ORGANIZATION" : "Organizace",
-        "TABLE_HEADER_USERNAME"     : "Uživatelské jméno"
+        "TABLE_HEADER_USERNAME"    : "Uživatelské jméno"
 
     },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents working on this repository.

## Changes

- Created `AGENTS.md` documenting:
  - Repository overview (data-only repo with Czech translation file for Apache Guacamole Client)
  - Development workflow (JSON validation using `python3` or `jq`)
  - Key notes about file format requirements

## Context

This repository contains only a Czech translation JSON file (`cs.json`) — no application code, build system, or test framework. The AGENTS.md provides future cloud agents with the context needed to validate and work with the translation file.

## Validation Evidence

[validation_output.log](https://cursor.com/agents/bc-c6a5e3b6-f603-469b-bc66-7b059e9cd532/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvalidation_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6a5e3b6-f603-469b-bc66-7b059e9cd532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6a5e3b6-f603-469b-bc66-7b059e9cd532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

